### PR TITLE
whitelist: add gcc packages

### DIFF
--- a/whitelist/recipes-whitelist.txt
+++ b/whitelist/recipes-whitelist.txt
@@ -37,3 +37,10 @@ tzcode
 update-rc.d
 util-macros
 which
+
+
+# debian gcc packages which build on ${TMPDIR}/work-shared/
+gcc-cross-aarch64
+libgcc
+libgcc-initial
+


### PR DESCRIPTION
meta-debian use $TMPDIR/work-shared directory to build gcc related packages.

gcc-8.inc set following value.

DEBIAN_UNPACK_DIR = "${TMPDIR}/work-shared/gcc-${PV}-${PR}/gcc-8-${PV}"

This is gcc package specifc, so do not any code in check script for gcc package
add packages in whitelist instead.