### PR TITLE
whitelist: Add glibc-locale in whitelist

### DIFF
--- a/whitelist/recipes-whitelist.txt
+++ b/whitelist/recipes-whitelist.txt
@@ -37,3 +37,6 @@ tzcode
 update-rc.d
 util-macros
 which
+
+# glibc-locale package use meta-debian's glibc source
+glibc-locale


### PR DESCRIPTION
Eventhough glibc-locale package version is different from meta-debian's glibc,
it created from meta-debian's glibc package.

glibc-common.inc sets PV so that version looks different from meta-debian.
https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta/recipes-core/glibc/glibc-common.inc?h=warrior&id=53b3e8c9d6e34f076a006df41cd2854b3cb30c71

Packaging glibc-locale is quite complex, recipes-core/glibc/glibc-package.inc stashes locale files when packaging glibc.
https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-core/glibc/glibc-package.inc?h=warrior#n162

Then, glibc-locale packaging process use it.